### PR TITLE
fix: breakpoint module

### DIFF
--- a/src/utils/breakpoints/breakpoints.js
+++ b/src/utils/breakpoints/breakpoints.js
@@ -1,6 +1,7 @@
 import variables from '../../styles/breakpoints.module.scss';
 
-const { extraSmallSize, smallSize, mediumSize, largeSize, largestSize } = variables;
+const { extraSmallSize, smallSize, mediumSize, largeSize, largestSize } =
+  variables;
 
 const events = new Map();
 events.set('from320', new Set());
@@ -9,6 +10,14 @@ events.set('from667', new Set());
 events.set('from1024', new Set());
 events.set('from1280', new Set());
 
+const obj = {
+  from320: window.matchMedia(`(min-width: ${extraSmallSize})`),
+  from360: window.matchMedia(`(min-width: ${smallSize})`),
+  from667: window.matchMedia(`(min-width: ${mediumSize})`),
+  from1024: window.matchMedia(`(min-width: ${largeSize})`),
+  from1280: window.matchMedia(`(min-width: ${largestSize})`),
+};
+
 export function listenBreakpoint(breakpoint, callback) {
   const callbacks = events.get(breakpoint);
   if (!callbacks) {
@@ -16,6 +25,7 @@ export function listenBreakpoint(breakpoint, callback) {
     return;
   }
   callbacks.add(callback);
+  callback(obj[breakpoint].matches);
 }
 
 export function unlistenBreakpoint(breakpoint, callback) {
@@ -26,13 +36,6 @@ export function unlistenBreakpoint(breakpoint, callback) {
   }
   callbacks.delete(callback);
 }
-const obj = {
-  from320: window.matchMedia(`(min-width: ${extraSmallSize})`),
-  from360: window.matchMedia(`(min-width: ${smallSize})`),
-  from667: window.matchMedia(`(min-width: ${mediumSize})`),
-  from1024: window.matchMedia(`(min-width: ${largeSize})`),
-  from1280: window.matchMedia(`(min-width: ${largestSize})`),
-};
 
 Object.keys(obj).forEach((key) => {
   obj[key].addEventListener('change', (e) => {


### PR DESCRIPTION
Closes

- **Description**
  Resolve a necessidade da execução da callback do breakpoint assim que o componente for montado, visto que o callback era ativado apenas depois de uma mudança no tamanho da tela

- **Cause**
  Callback não era executado assim que o módulo era chamado

- **Solution**
Fazer o callback assim que ele for chamado
</details>


<details open> 
  <summary>
    <b>Visual evidences :</b>
  </summary>

![image](https://github.com/devhatt/pet-dex-frontend/assets/35346206/06a594e0-9c53-4237-afb6-577380b60771)
![image](https://github.com/devhatt/pet-dex-frontend/assets/35346206/942a6199-c050-4fd1-b4fc-2397b6065bae)


</details>


- [ ] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

